### PR TITLE
Bump version for callback tests in kb_sdk_plus

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.0.9
+    0.0.10
 
 owners:
     [gaprice]


### PR DESCRIPTION
Tests expect version n in beta and version n+1 in dev